### PR TITLE
ポイント追加機能の実装

### DIFF
--- a/app/assets/stylesheets/_meigen-index.scss
+++ b/app/assets/stylesheets/_meigen-index.scss
@@ -30,8 +30,18 @@
           color: white;
         }
       }
+      #point-column {
+        width: 100%;
+        padding: 0;
+      }
+    }
+    &__remain-point {
+      color: white;
+      font-size: 15px;
     }
   }
+
+
 
   .meigen-container {
     width: 40vw;

--- a/app/assets/stylesheets/_meigen-show.scss
+++ b/app/assets/stylesheets/_meigen-show.scss
@@ -44,6 +44,14 @@
       }
     }
 
+    &__user-possession {
+      font-size: 20px;
+      text-align: center;
+      span {
+        color: red;
+      }
+    }
+
     &__content {
       @include clearfix();
       width: 100%;
@@ -179,15 +187,44 @@
       }
     }
 
-    &__comment-box {
+    &__form-box {
       @include clearfix();
-      width: 70%;
+      width: 100%;
       margin: 0 auto 10px;
       padding-bottom: 10px;
-      padding-left: 30%;
       box-shadow: 0 2px 4px #708090;
       overflow: scroll;
+      #point_value {
+        height:33px;
+      }
+      &__point {
+        float: left;
+        width: calc(30% - 10px);
+        padding-left: 10px;
+        text-align: center;
+        font-size: 20px;
+        .point-submit-btn {
+          background-color: #4169e1;
+          color: white;
+          font-size: 15px;
+          border-radius: 4px;
+          margin: 15px 0;
+          padding: 5px 10px;
+          border: none;
+          box-shadow: 3px 3px #000080;
+          outline: none;
+          margin: 0 auto 20px;
+          &:active {
+            position: relative;
+            top: 3px;
+            left: 3px;
+            box-shadow: none;
+          }
+        }
+      }
       &__comment {
+        float: right;
+        width: 70%;
         textarea {
           width: 87%;
           margin-top: 10px;
@@ -215,7 +252,12 @@
           }
         }
       }
-      &__index {
+      &__comment-index {
+        clear: both;
+        padding-left: 30px;
+        h2 {
+          text-align: center;
+        }
         &__items {
         @include clearfix();
         box-shadow: 0 2px 4px #708090;

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -1,0 +1,29 @@
+class PointsController < ApplicationController
+  def create
+    meigen = Meigen.find(create_params[:meigen_id])
+
+    point = Point.where('user_id = ? and meigen_id = ?', current_user.id, meigen.id)
+
+    if point.present?
+      current_point = current_user.point - create_params[:value].to_i + point[0].value
+      current_user.update(point: current_point)
+      point.update(create_params)
+    else
+      Point.create(create_params)
+    end
+    redirect_to meigen_path(meigen.id)
+  end
+
+
+  def show
+    @points = Point.where(user_id: current_user.id)
+  end
+
+
+  private
+
+  def create_params
+    params.require(:point).permit(:meigen_id, :value).merge(user_id: current_user.id)
+  end
+
+end

--- a/app/models/meigen.rb
+++ b/app/models/meigen.rb
@@ -2,9 +2,10 @@ class Meigen < ApplicationRecord
   belongs_to :user
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :points
 
   mount_uploader :image, ImageUploader
-  validates :content, presence: true
+  validates :content, presence: true, uniqueness: true
 
   acts_as_taggable
 

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -1,0 +1,7 @@
+class Point < ApplicationRecord
+  belongs_to :user
+  belongs_to :meigen
+
+  validates :value, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   has_many :meigens
   has_many :likes, dependent: :destroy
   has_many :comments
+  has_many :points
 end

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,4 +1,4 @@
-$(".meigen-show-container__comment-box__index").append("<%= j(render partial: 'meigens/comment-view', locals: { comment: @comment }) %>");
+$(".meigen-show-container__form-box__comment-index").append("<%= j(render partial: 'meigens/comment-view', locals: { comment: @comment }) %>");
 $("#comment-area").val('');
 
 var html = `<i class="far fa-comment">

--- a/app/views/likes/show.html.haml
+++ b/app/views/likes/show.html.haml
@@ -9,6 +9,14 @@
           ●投稿一覧
       %li
         ●いいね一覧
+      %li#point-column
+        = link_to "/points/#{current_user.id}" do
+          ●ポイント振った投稿一覧
+
+    .my-page-header__remain-point
+      %p
+        ポイント残高：
+        = current_user.point
 
   - @likes.each do |like|
     .meigen-container

--- a/app/views/meigens/_comment-view.html.haml
+++ b/app/views/meigens/_comment-view.html.haml
@@ -1,9 +1,9 @@
-.meigen-show-container__comment-box__index__items{class: "comment-id-#{comment.id}"}
-  .meigen-show-container__comment-box__index__items__left
+.meigen-show-container__form-box__comment-index__items{class: "comment-id-#{comment.id}"}
+  .meigen-show-container__form-box__comment-index__items__left
     %p
       = comment.user.name
       ：
-  .meigen-show-container__comment-box__index__items__center
+  .meigen-show-container__form-box__comment-index__items__center
     %p
       = simple_format(comment.content)
   - if comment.user_id == current_user.id

--- a/app/views/meigens/show.html.haml
+++ b/app/views/meigens/show.html.haml
@@ -19,6 +19,17 @@
             %li
               = link_to "削除", meigen_path(@meigen.id), method: :delete
 
+    - if @max_point.present?
+      .meigen-show-container__user-possession
+        %h1
+          この名言は
+          %span
+            = @max_point[0].user.name
+          さんのものです!
+          %span
+            = @max_point[0].value
+          ポイント振っています
+
     .meigen-show-container__content
       .meigen-show-container__content__left
         .meigen-show-container__content__left__header
@@ -60,13 +71,21 @@
           %li{class: "like-heart-#{@meigen.id}"}
             = render partial: "like-view", locals: { meigen: @meigen }
 
-    .meigen-show-container__comment-box
-      .meigen-show-container__comment-box__comment
+    .meigen-show-container__form-box
+      .meigen-show-container__form-box__point
+        - unless @meigen.user_id == current_user.id
+          %h1 ポイントを振る
+          = form_for @point, url: points_path do |f|
+            = f.select :value, @num, selected: @current_point
+            = f.hidden_field :meigen_id, value: @meigen.id
+            = f.submit "Push", class: "point-submit-btn"
+      .meigen-show-container__form-box__comment
         = form_for @comment, url: meigen_comments_path(@meigen), remote: true do |f|
           = f.text_area :content, placeholder: "コメントする", id: "comment-area"
           = f.submit "コメントする", class: "comment-submit-btn"
-      %h2 ＜コメント一覧＞
-      .meigen-show-container__comment-box__index
+
+      .meigen-show-container__form-box__comment-index
+        %h2 ＜コメント一覧＞
         = render partial: "comment-view", collection: @meigen.comments, as: "comment"
 
 

--- a/app/views/points/show.html.haml
+++ b/app/views/points/show.html.haml
@@ -1,0 +1,63 @@
+.wrapper-for-meigen-index
+  .my-page-header
+    %h1
+      = current_user.name
+      さんのマイページ
+    %ul
+      %li
+        = link_to "/users/#{current_user.id}" do
+          ●投稿一覧
+      %li
+        = link_to "/users/#{current_user.id}/likes" do
+          ●いいね一覧
+      %li#point-column
+        ●ポイント振った投稿一覧
+
+    .my-page-header__remain-point
+      %p
+        ポイント残高：
+        = current_user.point
+
+  - @points.each do |point|
+    .meigen-container
+      .meigen-container__header
+        .meigen-container__header--information
+          %ul
+            %li
+              投稿者：
+              = point.user.name
+            %li
+              = point.meigen.created_at
+        .meigen-container__header--access-detail
+          = link_to image_tag( 'arrow.png', { border: '0', alt: '新規登録' } ), "/meigens/#{point.meigen.id}"
+      .meigen-container__content
+        .meigen-container__content__left-content
+          = image_tag(point.meigen.image, width: '80')
+          .meigen-container__content__left-content__source
+            = point.meigen.source
+          - point.meigen.tag_list.each do |tag|
+            .meigen-container__content__left-content__tag
+              = tag
+        .meigen-container__content__right-content
+          .meigen-container__content__right-content__meigen
+            = simple_format(point.meigen.content)
+
+      .meigen-container__sns-function-bar
+        .meigen-container__sns-function-bar__box
+          %ul
+            %li
+              %i.far.fa-comment
+                = point.meigen.comments_count
+            %li{class: "like-heart-#{point.meigen.id}"}
+              = render partial: "meigens/like-view", locals: { meigen: point.meigen }
+
+
+      .meigen-container__scene-displayer
+        %i.fas.fa-chevron-down.accordion-btn
+
+      .meigen-container__scene-container
+        .meigen-container__scene-container__left-content
+          / %i.far.fa-flushed
+        .meigen-container__scene-container__right-content
+          .meigen-container__scene-container__right-content__scene
+            = point.meigen.scene

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,6 +9,14 @@
       %li
         = link_to "/users/#{current_user.id}/likes" do
           ●いいね一覧
+      %li#point-column
+        = link_to "/points/#{current_user.id}" do
+          ●ポイント振った投稿一覧
+
+    .my-page-header__remain-point
+      %p
+        ポイント残高：
+        = current_user.point
 
   - @meigens.each do |meigen|
     .meigen-container

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:show, :edit, :update]
-
+  resources :points, only: [:create, :show]
 
 end

--- a/db/migrate/20181102133032_add_point_to_meigen.rb
+++ b/db/migrate/20181102133032_add_point_to_meigen.rb
@@ -1,0 +1,5 @@
+class AddPointToMeigen < ActiveRecord::Migration[5.1]
+  def change
+    add_column :meigens, :point, :integer, default: 0
+  end
+end

--- a/db/migrate/20181102133401_add_point_to_user.rb
+++ b/db/migrate/20181102133401_add_point_to_user.rb
@@ -1,0 +1,5 @@
+class AddPointToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :point, :integer, default: 100
+  end
+end

--- a/db/migrate/20181102134034_create_points.rb
+++ b/db/migrate/20181102134034_create_points.rb
@@ -1,0 +1,9 @@
+class CreatePoints < ActiveRecord::Migration[5.1]
+  def change
+    create_table :points do |t|
+      t.references :user, foreign_key: true
+      t.references :meigen, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181103034214_remove_point_from_meigen.rb
+++ b/db/migrate/20181103034214_remove_point_from_meigen.rb
@@ -1,0 +1,5 @@
+class RemovePointFromMeigen < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :meigens, :point
+  end
+end

--- a/db/migrate/20181103045525_add_point_to_points.rb
+++ b/db/migrate/20181103045525_add_point_to_points.rb
@@ -1,0 +1,5 @@
+class AddPointToPoints < ActiveRecord::Migration[5.1]
+  def change
+    add_column :points, :value, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181030122049) do
+ActiveRecord::Schema.define(version: 20181103045525) do
 
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "content", null: false
@@ -42,6 +42,16 @@ ActiveRecord::Schema.define(version: 20181030122049) do
     t.integer "comments_count", default: 0
     t.string "source"
     t.index ["user_id"], name: "index_meigens_on_user_id"
+  end
+
+  create_table "points", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "user_id"
+    t.bigint "meigen_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value"
+    t.index ["meigen_id"], name: "index_points_on_meigen_id"
+    t.index ["user_id"], name: "index_points_on_user_id"
   end
 
   create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -83,6 +93,7 @@ ActiveRecord::Schema.define(version: 20181030122049) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.integer "point", default: 100
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -92,4 +103,6 @@ ActiveRecord::Schema.define(version: 20181030122049) do
   add_foreign_key "likes", "meigens"
   add_foreign_key "likes", "users"
   add_foreign_key "meigens", "users"
+  add_foreign_key "points", "meigens"
+  add_foreign_key "points", "users"
 end


### PR DESCRIPTION
# WHAT
投稿を自分のものにするために、限られたポイントで競う機能の実装。オークション形式。
```
新規登録で100pt獲得。投稿すると10pt獲得。
自分の投稿にはポイントを振れない。
投稿に10pt単位で振れる。
投稿詳細画面に最大ポイント獲得者が表示される。
ポイントを振ったことがある投稿はマイページで確認できる。
投稿が削除されるとその投稿に振ってあったポイントは返ってくる。
```

# WHY
ゲーム性の追加によるUX向上が狙い

投稿詳細画面
https://gyazo.com/bff38727f648980edb2a2ece16701c65